### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/dbarrett91/3ea5f265-5884-44a2-8bbc-5e6abca5e398/8b739305-d302-44d9-884c-b12cf36360cc/_apis/work/boardbadge/ea2f6b3c-fc64-4a11-8c89-fde38236f9d9)](https://dev.azure.com/dbarrett91/3ea5f265-5884-44a2-8bbc-5e6abca5e398/_boards/board/t/8b739305-d302-44d9-884c-b12cf36360cc/Microsoft.RequirementCategory)
 # APRemote
 Web based autopilot control using ESP32 and Seatalk1
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#12](https://dev.azure.com/dbarrett91/3ea5f265-5884-44a2-8bbc-5e6abca5e398/_workitems/edit/12). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.